### PR TITLE
Add `valid` and `invalid` in Validatedvalues.

### DIFF
--- a/src/main/scala/cats/scalatest/EitherValues.scala
+++ b/src/main/scala/cats/scalatest/EitherValues.scala
@@ -2,7 +2,6 @@ package cats.scalatest
 
 import org.scalatest.exceptions.{ TestFailedException, StackDepthException }
 
-import cats.syntax.either._
 import org.scalactic.source
 import scala.util.{ Either, Right, Left }
 

--- a/src/main/scala/cats/scalatest/ValidatedValues.scala
+++ b/src/main/scala/cats/scalatest/ValidatedValues.scala
@@ -26,6 +26,7 @@ trait ValidatedValues {
    *
    * <pre class="stREPL">
    *   result.value should be &gt; 15
+   *   result.valid.value should be(Valid(15))
    * </pre>
    *
    * Where it only matches if result is `Valid(9)`
@@ -50,6 +51,26 @@ trait ValidatedValues {
       case Valid(valid) =>
         throw new TestFailedException((_: StackDepthException) => Some(s"'$valid' is Valid, expected Invalid."), None, pos)
       case Invalid(left) => left
+    }
+
+    /**
+     * Returns the <code>Validated</code> passed to the constructor as a <code>Valid</code>, if it is a <code>Valid</code>,
+     * else throws <code>TestFailedException</code> with a detail message indicating the <code>Validated</code> was not a <code>Valid</code>.
+     */
+    def valid: Valid[T] = validated match {
+      case valid: Valid[T] => valid
+      case _ =>
+        throw new TestFailedException((_: StackDepthException) => Some("The Validated on which valid was invoked was not a Valid."), None, pos)
+    }
+
+    /**
+     * Returns the <code>Validated</code> passed to the constructor as an <code>Invalid</code>, if it is an <code>Invalid</code>,
+     * else throws <code>TestFailedException</code> with a detail message indicating the <code>Validated</code> was not an <code>Invalid</code>.
+     */
+    def invalid: Invalid[E] = validated match {
+      case invalid: Invalid[E] => invalid
+      case _ =>
+        throw new TestFailedException((_: StackDepthException) => Some("The Validated on which invalid was invoked was not an Invalid."), None, pos)
     }
   }
 }

--- a/src/test/scala/cats/scalatest/EitherMatchersSpec.scala
+++ b/src/test/scala/cats/scalatest/EitherMatchersSpec.scala
@@ -1,6 +1,6 @@
 package cats.scalatest
 
-import scala.util.{ Either, Right, Left }
+import scala.util.{ Right, Left }
 
 class EitherMatchersSpec extends TestBase with EitherMatchers {
   val goodHovercraft = Right(hovercraft)

--- a/src/test/scala/cats/scalatest/EitherValuesSpec.scala
+++ b/src/test/scala/cats/scalatest/EitherValuesSpec.scala
@@ -1,8 +1,5 @@
 package cats.scalatest
 
-import org.scalatest.{ FunSpec, Matchers }
-import Matchers._
-import org.scalatest.OptionValues._
 import org.scalatest.exceptions.TestFailedException
 import scala.util.{ Either, Right, Left }
 

--- a/src/test/scala/cats/scalatest/TestBase.scala
+++ b/src/test/scala/cats/scalatest/TestBase.scala
@@ -10,7 +10,7 @@ abstract class TestBase extends WordSpec with Matchers with OptionValues {
   /**
    * Shamelessly swiped from Scalatest.
    */
-  final def thisLineNumber = {
+  final def thisLineNumber: Int = {
     val st = Thread.currentThread.getStackTrace
 
     if (!st(2).getMethodName.contains("thisLineNumber"))

--- a/src/test/scala/cats/scalatest/ValidatedMatchersSpec.scala
+++ b/src/test/scala/cats/scalatest/ValidatedMatchersSpec.scala
@@ -1,8 +1,6 @@
 package cats.scalatest
 
-import org.scalatest.{ Matchers, FlatSpec }
-
-import cats.data.{ Validated, ValidatedNel, NonEmptyList }
+import cats.data.{ ValidatedNel, NonEmptyList }
 import cats.data.Validated.{ Valid, Invalid }
 
 class ValidatedMatchersSpec extends TestBase with ValidatedMatchers {

--- a/src/test/scala/cats/scalatest/ValidatedValuesSpec.scala
+++ b/src/test/scala/cats/scalatest/ValidatedValuesSpec.scala
@@ -38,5 +38,39 @@ class ValidatedValuesSpec extends TestBase {
       caught.failedCodeFileName.value should be("ValidatedValuesSpec.scala")
     }
   }
+
+  "valid on Validated" should {
+    "return the valid if it's a Valid" in {
+      val r = Validated.Valid(thisRecord)
+      r.valid should ===(r)
+    }
+
+    "throw TestFailedException if the Validated is Invalid" in {
+      val r: String Validated String = Validated.Invalid(thisTobacconist)
+      val caught =
+        intercept[TestFailedException] {
+          r.valid should ===(r)
+        }
+      caught.failedCodeLineNumber.value should equal(thisLineNumber - 2)
+      caught.failedCodeFileName.value should be("ValidatedValuesSpec.scala")
+    }
+  }
+
+  "invalid on Validated" should {
+    "return the invalid if it's a Invalid" in {
+      val r = Validated.Invalid(thisTobacconist)
+      r.invalid should ===(r)
+    }
+
+    "throw TestFailedException if the Validated is Valid" in {
+      val r: String Validated String = Validated.Valid(thisRecord)
+      val caught =
+        intercept[TestFailedException] {
+          r.invalid should ===(r)
+        }
+      caught.failedCodeLineNumber.value should equal(thisLineNumber - 2)
+      caught.failedCodeFileName.value should be("ValidatedValuesSpec.scala")
+    }
+  }
 }
 


### PR DESCRIPTION
This PR adds `valid` and `invalid` in Validatedvalues. This is useful for test cases where you want to match on the data contained in the Validated.

e.g. 
```scala
case class A(b: Int, c: Int)
Valid(A(1,2)).valid.foreach{ _.c should be(1)}
```
 This is based on [TryValues](https://github.com/scalatest/scalatest/blob/d40d278f2bb8e73431b942d87881fb6dbab75cb9/scalatest/src/main/scala/org/scalatest/TryValues.scala)

Also clean up some unused imports.