### PR TITLE
Switch to Scala Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+# Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming
+environment for all, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal
+appearance, body size, race, ethnicity, age, religion, nationality, or
+other such characteristics.
+
+Everyone is expected to follow the [Scala Code of Conduct] when
+discussing the project on the available communication channels. If you
+are being harassed, please contact us immediately so that we can
+support you.
+
+## Moderation
+
+For any questions, concerns, or moderation requests please contact a
+member of the project.
+
+[Scala Code of Conduct]: https://typelevel.org/code-of-conduct.html

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Scalatest bindings for cats.  Inspired by scalaz-scalatest.
 
 Apache 2.0 licensed.
 
-**cats-scalatest** is a [Typelevel](http://typelevel.org/) project. This means we embrace pure, typeful, functional programming, and provide a safe and friendly environment for teaching, learning, and contributing as described in the Typelevel [Code of Conduct](http://typelevel.org/conduct.html).
+**cats-scalatest** is a [Typelevel](http://typelevel.org/) project. This means we embrace pure, typeful, functional programming, and provide a safe and friendly environment for teaching, learning, and contributing as described in the [Scala Code of Conduct](http://typelevel.org/code-of-conduct.html).
 
 ## Setup
 


### PR DESCRIPTION
Typelevel has [adopted the Scala Code of Conduct](https://typelevel.org/blog/2019/05/01/typelevel-switches-to-scala-code-of-conduct.html) and is encouraging all member projects to switch.