### PR TITLE
Add support for Scala.js

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,22 +1,34 @@
-name := "cats-scalatest"
-organization := "com.ironcorelabs"
-
-scalaVersion := "2.12.7"
-crossScalaVersions := Seq("2.11.12", "2.12.7")
-
-com.typesafe.sbt.SbtScalariform.scalariformSettings
-
-scalacOptions ++= Seq(
-  "-deprecation",
-  "-unchecked"
-)
-
-resolvers += Resolver.sonatypeRepo("releases")
+import sbtcrossproject.CrossPlugin.autoImport.{CrossType, crossProject}
 
 lazy val catsVersion = "1.6.0"
 
-libraryDependencies ++= Seq(
-  "org.typelevel" %% "cats-core" % catsVersion,
-  "org.typelevel" %% "cats-macros" % catsVersion,
-  "org.scalatest" %% "scalatest" % "3.0.5"
-)
+// Due to the cross project being in(file(".")), we need to prevent
+// the automatic root project from compiling.
+Compile / unmanagedSourceDirectories := Nil
+Test / unmanagedSourceDirectories := Nil
+
+lazy val `cats-scalatest` = crossProject(JVMPlatform, JSPlatform)
+  .withoutSuffixFor(JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("."))
+  .settings(
+    name := "cats-scalatest",
+    organization := "com.ironcorelabs",
+
+    scalaVersion := "2.12.8",
+    crossScalaVersions := Seq("2.11.12", "2.12.8"),
+
+    scalacOptions ++= Seq(
+      "-deprecation",
+      "-unchecked"
+    ),
+
+    resolvers += Resolver.sonatypeRepo("releases"),
+
+    libraryDependencies ++= Seq(
+      "org.typelevel" %%% "cats-core" % catsVersion,
+      "org.typelevel" %%% "cats-macros" % catsVersion,
+      "org.scalatest" %%% "scalatest" % "3.0.7"
+    )
+  )
+

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ lazy val catsVersion = "1.6.0"
 // the automatic root project from compiling.
 Compile / unmanagedSourceDirectories := Nil
 Test / unmanagedSourceDirectories := Nil
+publishArtifact := false
 
 lazy val `cats-scalatest` = crossProject(JVMPlatform, JSPlatform)
   .withoutSuffixFor(JVMPlatform)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,14 +1,21 @@
 // Per the readme, this is needed in 1.3 to work around an issue
 resolvers += Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksamuel/sbt-plugins/"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.7.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
+
+addSbtPlugin("org.portable-scala" % "sbt-crossproject" % "0.6.0")
+
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.27")
+

--- a/src/test/scala/cats/scalatest/EitherValuesSpec.scala
+++ b/src/test/scala/cats/scalatest/EitherValuesSpec.scala
@@ -18,7 +18,9 @@ class EitherValuesSpec extends TestBase {
         intercept[TestFailedException] {
           r.value should ===(thisRecord)
         }
-      caught.failedCodeLineNumber.value should equal(thisLineNumber - 2)
+      if (isJVM) {
+        caught.failedCodeLineNumber.value should equal(thisLineNumber - 3)
+      }
       caught.failedCodeFileName.value should be("EitherValuesSpec.scala")
     }
   }
@@ -34,7 +36,9 @@ class EitherValuesSpec extends TestBase {
       val caught = intercept[TestFailedException] {
         r.leftValue
       }
-      caught.failedCodeLineNumber.value should equal(thisLineNumber - 2)
+      if (isJVM) {
+        caught.failedCodeLineNumber.value should equal(thisLineNumber - 3)
+      }
       caught.failedCodeFileName.value should be("EitherValuesSpec.scala")
     }
   }

--- a/src/test/scala/cats/scalatest/TestBase.scala
+++ b/src/test/scala/cats/scalatest/TestBase.scala
@@ -7,6 +7,10 @@ abstract class TestBase extends WordSpec with Matchers with OptionValues {
   val thisTobacconist = "Ah! I will not buy this tobacconist's, it is scratched."
   val hovercraft = "Yes, cigarettes. My hovercraft is full of eels."
 
+  // As advised by @sjrd: https://gitter.im/scala-js/scala-js?at=5ce51e9b9d64e537bcef6f08
+  final val isJS = 1.0.toString() == "1"
+  final val isJVM = !isJS
+
   /**
    * Shamelessly swiped from Scalatest.
    */

--- a/src/test/scala/cats/scalatest/ValidatedValuesSpec.scala
+++ b/src/test/scala/cats/scalatest/ValidatedValuesSpec.scala
@@ -18,7 +18,9 @@ class ValidatedValuesSpec extends TestBase {
         intercept[TestFailedException] {
           r.value should ===(thisRecord)
         }
-      caught.failedCodeLineNumber.value should equal(thisLineNumber - 2)
+      if (isJVM) {
+        caught.failedCodeLineNumber.value should equal(thisLineNumber - 3)
+      }
       caught.failedCodeFileName.value should be("ValidatedValuesSpec.scala")
     }
   }
@@ -34,7 +36,9 @@ class ValidatedValuesSpec extends TestBase {
       val caught = intercept[TestFailedException] {
         r.invalidValue
       }
-      caught.failedCodeLineNumber.value should equal(thisLineNumber - 2)
+      if (isJVM) {
+        caught.failedCodeLineNumber.value should equal(thisLineNumber - 3)
+      }
       caught.failedCodeFileName.value should be("ValidatedValuesSpec.scala")
     }
   }
@@ -51,7 +55,9 @@ class ValidatedValuesSpec extends TestBase {
         intercept[TestFailedException] {
           r.valid should ===(r)
         }
-      caught.failedCodeLineNumber.value should equal(thisLineNumber - 2)
+      if (isJVM) {
+        caught.failedCodeLineNumber.value should equal(thisLineNumber - 3)
+      }
       caught.failedCodeFileName.value should be("ValidatedValuesSpec.scala")
     }
   }
@@ -68,7 +74,9 @@ class ValidatedValuesSpec extends TestBase {
         intercept[TestFailedException] {
           r.invalid should ===(r)
         }
-      caught.failedCodeLineNumber.value should equal(thisLineNumber - 2)
+      if (isJVM) {
+        caught.failedCodeLineNumber.value should equal(thisLineNumber - 3)
+      }
       caught.failedCodeFileName.value should be("ValidatedValuesSpec.scala")
     }
   }


### PR DESCRIPTION
Also build on sbt 1.2.8.

In the test code, the line number checks are only done on JVM because the stack trace method doesn’t work correctly on JS. Scalatest has a [macro-based version](https://github.com/scalatest/scalatest/blob/release-3.0.7/common-test/src/main/scala/org/scalatest/LineNumberHelper.scala) of `thisLineNumber` but swiping that would require a new module due to the restriction that macros cannot be used and defined in the same module.