### PR TITLE
Use Scala3 LTS release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ inThisBuild(
     ),
     homepage := Some(url("http://github.com/ironcorelabs/cats-scalatest")),
     licenses := Seq("Apache-2.0" -> url("http://www.opensource.org/licenses/Apache-2.0")),
-    scalaVersion := "3.7.1",
+    scalaVersion := "3.3.6",
     crossScalaVersions := Seq(scalaVersion.value)
   )
 )


### PR DESCRIPTION
Librairies shouldn't use latest version otherwise people staying on LTS versions can't use your lib